### PR TITLE
Adopt DispatchQueue API

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,9 +1,10 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.5
 import PackageDescription
 
 
 let package = Package(
 	name: "FSEventsWrapper",
+	platforms: [.macOS(.v10_13)],
 	products: [
 		.library(name: "FSEventsWrapper", targets: ["FSEventsWrapper"]),
 	],

--- a/Sources/FSEventsWrapper/FSEvent.swift
+++ b/Sources/FSEventsWrapper/FSEvent.swift
@@ -11,9 +11,9 @@ import Foundation
 
 
 
-public enum FSEvent {
+public enum FSEvent : Sendable {
 	
-	public enum MustScanSubDirsReason {
+	public enum MustScanSubDirsReason : Sendable {
 		
 		case userDropped
 		case kernelDropped
@@ -22,7 +22,7 @@ public enum FSEvent {
 		
 	}
 	
-	public enum ItemType {
+	public enum ItemType : Sendable {
 		
 		case file
 		case dir

--- a/Tests/FSEventsWrapperTests/FSEventsWrapperTests.swift
+++ b/Tests/FSEventsWrapperTests/FSEventsWrapperTests.swift
@@ -29,7 +29,7 @@ class FSEventsWrapperTests: XCTestCase {
 	}
 	
 	func testBasicMonitoring() {
-		let handler = { (stream: FSEventStream, event: FSEvent) in
+		let handler: FSEventStream.Callback = { (stream: FSEventStream, event: FSEvent) in
 			NSLog("%@", String(describing: event))
 			stream.stopWatching()
 		}


### PR DESCRIPTION
I've been working to migrate a library of mine over be compatible with Swift concurrency. It's ended up being Non-Trivial. One of the issues I ran into was FSEventsWrapper's use of runloops. It is still possible to use with concurrency, by scheduling on the main loop. But, I noticed that these APIs are now deprecated. So, I thought it could be worth the change.

This is a breaking change. So, I would understand hesitation. I'm happy to discuss!

(I also have another currently-internal change that exposes an AsyncSequence of FSEvents. However, I thought it would make more sense to merge this first before considering that one.)