### PR TITLE
FSEventAsyncStream: additional parameters

### DIFF
--- a/Sources/FSEventAsyncStream.swift
+++ b/Sources/FSEventAsyncStream.swift
@@ -17,7 +17,7 @@ public struct FSEventAsyncStream : AsyncSequence {
 		private let eventStream: FSEventStream?
 		private var streamIterator: AsyncStream<FSEvent>.Iterator
 		
-		init(path: String, flags: FSEventStreamCreateFlags) {
+		init(path: String, since startId: FSEventStreamEventId?, updateInterval: CFTimeInterval, flags: FSEventStreamCreateFlags) {
 			let (stream, continuation) = AsyncStream<FSEvent>.makeStream()
 			
 			self.eventStream = FSEventStream(path: path, fsEventStreamFlags: flags, callback: { _, event in
@@ -39,15 +39,22 @@ public struct FSEventAsyncStream : AsyncSequence {
 	}
 	
 	public let path: String
+	public let startId: FSEventStreamEventId?
+	public let updateInterval: CFTimeInterval
 	public let flags: FSEventStreamCreateFlags
 	
-	public init(path: String, flags: FSEventStreamCreateFlags = FSEventStreamCreateFlags(kFSEventStreamCreateFlagNone)) {
+	public init(path: String,
+				since startId: FSEventStreamEventId? = nil,
+				updateInterval: CFTimeInterval = 0,
+				flags: FSEventStreamCreateFlags = FSEventStreamCreateFlags(kFSEventStreamCreateFlagNone)) {
 		self.path = path
+		self.startId = startId
+		self.updateInterval = updateInterval
 		self.flags = flags
 	}
 	
 	public func makeAsyncIterator() -> FSEventAsyncIterator {
-		FSEventAsyncIterator(path: path, flags: flags)
+		FSEventAsyncIterator(path: path, since: startId, updateInterval: updateInterval, flags: flags)
 	}
 	
 }


### PR DESCRIPTION
Pass the `sinceId` and `updateInterval` parameters through to `FSEventStream`.